### PR TITLE
WIP: Fix erroneous coverage3 call in tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,7 @@ commands =
 basepython = python3
 setenv =
   {[testenv]setenv}
-  PYTHON=coverage3 run --source prototype_template --parallel-mode -m pytest tests/
 commands =
+  coverage3 run --source prototype_template --parallel-mode -m unittest
   coverage3 combine
   coverage3 report --fail-under=80


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [X] I have added the tests to cover my changes.
- 
-->

### Summary
coverage testing did not point to the tests directory


### Details and comments
Fixed coverage3 command in tox.ini to properly point to the source and call the tests using pytest.
