### PR TITLE
Enable tests when a PR is made from a fork

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -2,9 +2,13 @@ name: Code coverage
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - main
+      - 'stable/**'
   pull_request:
-    branches: [ main ]
+    branches:
+      - main
+      - 'stable/**'
 
 jobs:
   coverage:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,9 +2,13 @@ name: Styles check
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - main
+      - 'stable/**'
   pull_request:
-    branches: [ main ]
+    branches:
+      - main
+      - 'stable/**'
 
 jobs:
   lint:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,9 +2,13 @@ name: Tests
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - main
+      - 'stable/**'
   pull_request:
-    branches: [ main ]
+    branches:
+      - main
+      - 'stable/**'
 
 jobs:
   tests:


### PR DESCRIPTION
The description of `on: [push]` [within the github documentation](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#using-a-single-event) says that such a workflow "will run when a push is made to any branch in the workflow's repository."

This implies to me that it might not be triggered when a pull request is opened from a fork.  (Forking is currently disabled in this repository, so there's no quick way to test this here.)  Under this assumption, I have changed the workflows to test explicitly any time a pull request is made against `main`.

I'm not sure if we will ever have `stable/**` branches that we might want to continue to develop, but if we do, we should enable tests there too, [like qiskit-optimization has done](https://github.com/Qiskit/qiskit-optimization/blob/ddb4a1a707fbc942fb868f443a2064cc16f6d2cb/.github/workflows/main.yml#L15-L23). (EDIT: added to this PR in 7e439321f64ad5a86761bc080c90f6d444f77851.)