### PR TITLE
Fix {black,lint} environment re-creation on tox4

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-minversion = 2.1
+minversion = 3.15
 envlist = py37, py38, py39, py310, lint, coverage
 skipsdist = true
 
@@ -17,17 +17,14 @@ commands =
   python -m pytest -v --doctest-modules
   treon docs --threads 2
 
-[testenv:lint]
-envdir = .tox/lint
+[testenv:{black,lint}]
+envdir = {toxworkdir}/lint
 commands =
-  black --check {posargs} .
-  pylint -rn prototype_template tests
-  nbqa pylint docs/
-  mypy .
-
-[testenv:black]
-envdir = .tox/lint
-commands = black {posargs} .
+  black: black {posargs} .
+  lint: black --check {posargs} .
+  lint: pylint -rn prototype_template tests
+  lint: nbqa pylint docs/
+  lint: mypy .
 
 [testenv:coverage]
 basepython = python3


### PR DESCRIPTION
I've found that the existing tox configuration, which has the black and lint environments sharing the same `envdir`, works fine on tox3 but on tox4 results in the environments being re-created every time one toggles between them.

There is a suggested solution [on StackOverflow](https://stackoverflow.com/a/64060423), but it seems not to work as expected on tox4, so I've opened an issue there: https://github.com/tox-dev/tox/issues/2362

This uses [generative section names](https://tox.wiki/en/latest/config.html#generative-section-names), hence the bumping of `minversion` to tox 3.15.

I'll plan to merge this PR once the above issue with tox is resolved.