### PR TITLE
Migrate to pathlib

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,23 +17,16 @@ Sphinx documentation builder
 """
 
 # General options:
-import os
+from pathlib import Path
 
 project = "Template project"
 copyright = "2022"  # pylint: disable=redefined-builtin
 author = ""
 
+_rootdir = Path(__file__).parent.parent
+
 # The full version, including alpha/beta/rc tags
-with open(
-    os.path.join(
-        os.path.dirname(os.path.abspath(__file__)),
-        "..",
-        "prototype_template",
-        "VERSION.txt",
-    ),
-    "r",
-) as f:
-    release = f.read()
+release = (_rootdir / "prototype_template" / "VERSION.txt").read_text().strip()
 # The short X.Y version
 version = release
 


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This looks a lot cleaner to me than the `os.path.dirname()` stuff that existed previously (and which I am the author of).

### Details and comments

