### PR TITLE
Remove setup.cfg (for now)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[metadata]
-description_file = README.md


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This removes `setup.cfg`.  The information in this file currently contradicts what is in `setup.py`. We might (will likely) decide to migrate to `setup.cfg` in the future instead of `setup.py`, but right now this file is not adding anything.

### Details and comments

