### PR TITLE
`tox.ini`: `skip_install = true` in envs as appropriate

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,7 @@ commands =
 
 [testenv:lint]
 envdir = .tox/lint
+skip_install = true
 commands =
   black --check {posargs} .
   pylint -rn prototype_template tests
@@ -27,6 +28,7 @@ commands =
 
 [testenv:black]
 envdir = .tox/lint
+skip_install = true
 commands = black {posargs} .
 
 [testenv:coverage]
@@ -39,6 +41,7 @@ commands =
   coverage3 report --fail-under=80
 
 [testenv:docs]
+skip_install = false
 deps =
     -r{toxinidir}/requirements-dev.txt
 commands =


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This sets `skip_install = true` in the tox environments where installation of the sdist is not necessary (lint, black, docs).  This saves a bit of time executing these environments.

### Details and comments

