### PR TITLE
Update CONTRIBUTING.md with default black line length

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ Users are encouraged to use GitHub Discussions for engaging with researchers, de
 
 ### Project Code Style
 
-Code in this repository should conform to PEP8 standards. Style/lint checks are run to validate this. Line length must be limited to no more than 100 characters.
+Code in this repository should conform to PEP8 standards. Style/lint checks are run to validate this. Line length must be limited to no more than 88 characters.
 
 ### Pull Request Checklist
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Black uses a line length of 88 by default, so this updates `CONTRIBUTING.md` accordingly.  Alternatively, we could use a line length of 100; in this case, we would have to pass it as an argument to `black` in `tox.ini`.

### Details and comments

