### PR TITLE
Fix CITATION.bib preview workflow with new repo names

### DIFF
--- a/.github/workflows/citation.yml
+++ b/.github/workflows/citation.yml
@@ -34,15 +34,16 @@ jobs:
           if [ -f "CITATION.bib" ]; then
           arr=(${GITHUB_REPOSITORY//\// })
           export REPO=${arr[1]}
+          export PROTOTYPE=${REPO#"prototype-"}
           cat <<- EOF > preview.tex
           \documentclass[preprint,aps,physrev,notitlepage]{revtex4-2}
           \usepackage{hyperref}
           \begin{document}
-          \title{\texttt{$REPO} BibTeX test}
+          \title{\texttt{$PROTOTYPE} BibTeX test}
           \maketitle
           \noindent
-          \texttt{$REPO}
-          \cite{$REPO}
+          \texttt{$PROTOTYPE}
+          \cite{$PROTOTYPE}
           \bibliography{CITATION}
           \end{document}
           EOF

--- a/.github/workflows/citation.yml
+++ b/.github/workflows/citation.yml
@@ -33,7 +33,7 @@ jobs:
         run: |
           if [ -f "CITATION.bib" ]; then
           arr=(${GITHUB_REPOSITORY//\// })
-          export REPO=${arr[1]}
+          REPO=${arr[1]}
           export PROTOTYPE=${REPO#"prototype-"}
           cat <<- EOF > preview.tex
           \documentclass[preprint,aps,physrev,notitlepage]{revtex4-2}


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The citation preview workflow currently assumes that the citation key in `CITATION.bib` is the name of the repository.  However, we recently renamed each repository to have the prefix `prototype-`.  This change removes this prefix, if it exists, from the expected citation key name in `CITATION.bib`.  This modified workflow will continue to work if the prefix is removed again in the future.

### Details and comments

